### PR TITLE
Specifying npm version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,7 @@
 {
+  "engines": {
+    "npm": "6.x"
+  },
   "dependencies": {
     "grommet": "^2.20.0",
     "grommet-icons": "^4.7.0",


### PR DESCRIPTION
The default on heroku changed to 8.x and that failed during build, the last passing version was 6.x